### PR TITLE
Resolve delay for escape on neovim.

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -1,5 +1,6 @@
 set-option -g mode-keys vi
 set-option -g default-command "reattach-to-user-namespace -l zsh"
+set -g escape-time 10
 
 set -g @tpm_plugins " \
   tmux-plugins/tpm \


### PR DESCRIPTION
FYI: https://github.com/neovim/neovim/wiki/FAQ#esc-in-tmux-or-gnu-screen-is-delayed