### PR TITLE
With an environment variable 'WORKON_HOME', I reduce the dependencies of specified environments.

### DIFF
--- a/home/.config/nvim/init.vim
+++ b/home/.config/nvim/init.vim
@@ -1,5 +1,5 @@
 set clipboard+=unnamed
 
-" Depend on my specified environment.
-let g:python_host_prog = $HOME.'/.homesick/repos/dotfiles/home/.virtualenvs/py2.7/bin/python'
-let g:python3_host_prog = $HOME.'/.homesick/repos/dotfiles/home/.virtualenvs/py3.6/bin/python'
+" Depend on virtualenvs with specified names.
+let g:python_host_prog = $WORKON_HOME.'/py2.7/bin/python'
+let g:python3_host_prog = $WORKON_HOME.'/py3.6/bin/python'


### PR DESCRIPTION
Remaining dependencies are virtualenv names.(py2.7 and py3.6)